### PR TITLE
Fixed STREAMING environment variable not being interpreted as boolean.

### DIFF
--- a/src/handler.py
+++ b/src/handler.py
@@ -11,7 +11,7 @@ import os
 # Prepare the model and tokenizer
 MODEL_NAME = os.environ.get('MODEL_NAME')
 MODEL_BASE_PATH = os.environ.get('MODEL_BASE_PATH', '/runpod-volume/')
-STREAMING = os.environ.get('STREAMING', False)
+STREAMING = os.environ.get('STREAMING', False) == 'True'
 TOKENIZER = os.environ.get('TOKENIZER', None)
 
 if not MODEL_NAME:


### PR DESCRIPTION
Currently, if the environment variable STREAMING is set to False, the result will not be the intended one. The STREAMING python variable will be of type string and contain 'False' and `if STREAMING:` will evaluate to True.