### PR TITLE
Update Dockerfile env key that is deprecated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG WORKER_CUDA_VERSION=11.8 # Required duplicate to keep in scope
 ENV WORKER_CUDA_VERSION=${WORKER_CUDA_VERSION} \
     HF_DATASETS_CACHE="/runpod-volume/huggingface-cache/datasets" \
     HUGGINGFACE_HUB_CACHE="/runpod-volume/huggingface-cache/hub" \
-    TRANSFORMERS_CACHE="/runpod-volume/huggingface-cache/hub" \
+    HF_HOME="/runpod-volume/huggingface-cache/hub" \
     HF_TRANSFER=1
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG WORKER_CUDA_VERSION=11.8 # Required duplicate to keep in scope
 ENV WORKER_CUDA_VERSION=${WORKER_CUDA_VERSION} \
     HF_DATASETS_CACHE="/runpod-volume/huggingface-cache/datasets" \
     HUGGINGFACE_HUB_CACHE="/runpod-volume/huggingface-cache/hub" \
-    HF_HOME="/runpod-volume/huggingface-cache/hub" \
+    HF_HOME="/runpod-volume/huggingface-cache" \
     HF_TRANSFER=1
 
 


### PR DESCRIPTION
/usr/local/lib/python3.10/dist-packages/transformers/utils/hub.py:123: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
  warnings.warn(