### PR TITLE
Add TORCH_CUDA_ARCH_LIST to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Base image - Set default to CUDA 11.8
 ARG WORKER_CUDA_VERSION=11.8
-FROM runpod/base:0.4.2-cuda${WORKER_CUDA_VERSION}.0 as builder
+FROM runpod/base:0.4.4-cuda${WORKER_CUDA_VERSION}.0 as builder
 
 ARG WORKER_CUDA_VERSION=11.8 # Required duplicate to keep in scope
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ ENV WORKER_CUDA_VERSION=${WORKER_CUDA_VERSION} \
     HF_DATASETS_CACHE="/runpod-volume/huggingface-cache/datasets" \
     HUGGINGFACE_HUB_CACHE="/runpod-volume/huggingface-cache/hub" \
     TRANSFORMERS_CACHE="/runpod-volume/huggingface-cache/hub" \
-    HF_TRANSFER=1
+    HF_TRANSFER=1 \
+    TORCH_CUDA_ARCH_LIST="8.6 8.9"
 
 
 # Install Python dependencies


### PR DESCRIPTION
Believe this fixes building docker images when a GPU is not present. Have successfully completed a docker build and deployed the Image to runpod.

The architectures should match the capabilities of the serverless workers but if I'm missing any let me know

Should close #25 too hopefully. 