### PR TITLE
feat: add `max_model_length` setup key

### DIFF
--- a/src/engine.py
+++ b/src/engine.py
@@ -47,6 +47,7 @@ class VLLMEngine:
             "disable_log_requests": bool(int(os.getenv("DISABLE_LOG_REQUESTS", 1))),
             "gpu_memory_utilization": float(os.getenv("GPU_MEMORY_UTILIZATION", 0.98)),
             "tensor_parallel_size": self._get_num_gpu_shard(),
+            "max_model_len": int(os.getenv("MAX_MODEL_LEN", 4096)),
         }
 
     def _initialize_llm(self):


### PR DESCRIPTION
Fixes this message received when trying to run a mistral-7b finetune:
```
ValueError: The model's max seq len (32768) is larger than the maximum number of tokens that can be stored in KV cache (29568). Try increasing `gpu_memory_utilization` or decreasing `max_model_len` when initializing the engine.
```

`gpu_memory_utilization` is already set to `0.98` by default. With this PR `MAX_MODEL_LEN` can be set as environment variable. Expects an integer, defaults to 4096.