### PR TITLE
fix: build error if no `TOKENIZER_NAME` provided

### DIFF
--- a/builder/download_model.py
+++ b/builder/download_model.py
@@ -27,9 +27,8 @@ def move_files(src_dir, dest_dir):
         
 if __name__ == "__main__":
     model, download_dir = os.getenv("MODEL_NAME"), os.getenv("HF_HOME")
-    tokenizer = os.getenv("TOKENIZER_NAME", model)
-    if len(tokenizer) == 0:
-        tokenizer = model
+    tokenizer = os.getenv("TOKENIZER_NAME") or model
+
     revisions = {
         "model": os.getenv("MODEL_REVISION") or None,
         "tokenizer": os.getenv("TOKENIZER_REVISION") or None

--- a/builder/download_model.py
+++ b/builder/download_model.py
@@ -28,6 +28,8 @@ def move_files(src_dir, dest_dir):
 if __name__ == "__main__":
     model, download_dir = os.getenv("MODEL_NAME"), os.getenv("HF_HOME")
     tokenizer = os.getenv("TOKENIZER_NAME", model)
+    if len(tokenizer) == 0:
+        tokenizer = model
     revisions = {
         "model": os.getenv("MODEL_REVISION") or None,
         "tokenizer": os.getenv("TOKENIZER_REVISION") or None


### PR DESCRIPTION
Building an image with a model baked in throws this error after downloading all the weights if no argument for `TOKENIZER_NAME ` was provided:

```bash
105.2 Traceback (most recent call last):
105.2   File "/download_model.py", line 55, in <module>
105.2     tokenizer_folder = download_extras_or_tokenizer(tokenizer, download_dir, revisions["tokenizer"])
105.2   File "/download_model.py", line 11, in download_extras_or_tokenizer
105.2     folder = snapshot_download(
105.2   File "/usr/local/lib/python3.10/dist-packages/huggingface_hub/utils/_validators.py", line 110, in _inner_fn
105.2     validate_repo_id(arg_value)
105.2   File "/usr/local/lib/python3.10/dist-packages/huggingface_hub/utils/_validators.py", line 164, in validate_repo_id
105.2     raise HFValidationError(
105.2 huggingface_hub.utils._validators.HFValidationError: Repo id must use alphanumeric chars or '-', '_', '.', '--' and '..' are forbidden, '-' and '.' cannot start or end the name, max length is 96: ''.
```

This happens, as `TOKENIZER_NAME` is set to default value empty string in Dockerfile, which in turn sets the tokenizer value in line 30 to an empty string as well.