### PR TITLE
Fix runtime error for dict chat templates

### DIFF
--- a/src/engine.py
+++ b/src/engine.py
@@ -124,9 +124,13 @@ class OpenAIvLLMEngine:
         self.raw_openai_output = bool(int(os.getenv("RAW_OPENAI_OUTPUT", 1)))
 
     def _initialize_engines(self):
+        chat_template = self.tokenizer.tokenizer.chat_template
+        if isinstance(chat_template, dict):
+            # "default" key should be present in a valid dict chat template
+            chat_template = chat_template["default"]
         self.chat_engine = OpenAIServingChat(
             self.llm, self.served_model_name, self.response_role,
-            chat_template=self.tokenizer.tokenizer.chat_template
+            chat_template=chat_template
         )
         self.completion_engine = OpenAIServingCompletion(self.llm, self.served_model_name)
     


### PR DESCRIPTION
A chat template in HuggingFace transformers [can be a dict](https://huggingface.co/docs/transformers/main/en/chat_templating#why-do-some-models-have-multiple-templates). This is the case, for example, for a popular [Command-R](https://huggingface.co/CohereForAI/c4ai-command-r-v01) model. For these models, a Runpod serverless endpoint created from the vLLM template will crash and reboot repeatedly, because OpenAIServingChat class [expects](https://github.com/runpod/vllm-fork-for-sls-worker/blob/ba8f5e79e1972f7cc7110e8bfb43d895b35da2ea/vllm/entrypoints/openai/serving_chat.py#L34) a str in its chat_template constructor argument.

This patch fixes it, replacing a dict chat_template with a string value corresponding to a "default" key. This key should exist in all valid chat templates, as transformers would crash otherwise during [apply_chat_template function](https://github.com/huggingface/transformers/blob/6c1d0b069de22d7ed8aa83f733c25045eea0585d/src/transformers/tokenization_utils_base.py#L1687).