### PR TITLE
add multi lora support

### DIFF
--- a/src/engine.py
+++ b/src/engine.py
@@ -133,8 +133,13 @@ class OpenAIvLLMEngine(vLLMEngine):
         lora_modules = os.getenv('LORA_MODULES', None)
         if lora_modules is not None:
             try:
-                lora_modules = json.loads(lora_modules)
-                lora_modules = [LoRAModulePath(**lora_modules)]
+                lora_modules_dict = json.loads(lora_modules)
+                if type(lora_modules_dict) == list:
+                    lora_modules = []
+                    for adapter in lora_modules_dict:
+                        lora_modules.append(LoRAModulePath(**adapter))
+                else:
+                    lora_modules = [LoRAModulePath(**lora_modules_dict)]
             except:
                 lora_modules = None
 


### PR DESCRIPTION
in addition to the last pull reqeust, now you can also use multiple lora adapters.

Now you can use a single adapter as input (as before):
`{"name": "xxx", "path": "xxx/xxxxx", "base_model_name": "xxx/xxxx"}`

And also as a list of adapters:
`[{"name": "xxx", "path": "xxx/xxxxx", "base_model_name": "xxx/xxxx"},{"name": "xxx", "path": "xxx/xxxxx", "base_model_name": "xxx/xxxx"},...]`

