### PR TITLE
feat: bitsandbytes quantization

### DIFF
--- a/builder/requirements.txt
+++ b/builder/requirements.txt
@@ -9,3 +9,4 @@ pydantic
 pydantic-settings
 hf-transfer
 transformers
+bitsandbytes>=0.44.0

--- a/worker-config.json
+++ b/worker-config.json
@@ -564,7 +564,8 @@
       { "value": "None", "label": "None" },
       { "value": "awq", "label": "AWQ" },
       { "value": "squeezellm", "label": "SqueezeLLM" },
-      { "value": "gptq", "label": "GPTQ" }
+      { "value": "gptq", "label": "GPTQ" },
+      { "value": "bitsandbytes", "label": "BitsAndBytes" }
     ]
   },
   "ROPE_SCALING": {


### PR DESCRIPTION
Installs `bitsandbytes>=0.44.0` and adds the `bitsandbytes` value to the `QUANTIZATION` select.

See [vLLM bnb docs](https://docs.vllm.ai/en/latest/quantization/bnb.html).