### PR TITLE
fix: openai tool calling

### DIFF
--- a/src/engine.py
+++ b/src/engine.py
@@ -146,8 +146,8 @@ class OpenAIvLLMEngine(vLLMEngine):
             base_model_paths=self.base_model_paths,
             response_role=self.response_role,
             chat_template=self.tokenizer.tokenizer.chat_template,
-            enable_auto_tools=DEFAULT_ARGS.enable_auto_tool_choice,
-            tool_parser=DEFAULT_ARGS.tool_call_parser,
+            enable_auto_tools=os.getenv('ENABLE_AUTO_TOOL_CHOICE', 'false').lower() == 'true',
+            tool_parser=os.getenv('TOOL_CALL_PARSER', "") or None,
             lora_modules=lora_modules,
             prompt_adapters=None,
             request_logger=None

--- a/src/engine.py
+++ b/src/engine.py
@@ -17,7 +17,7 @@ from vllm.entrypoints.openai.serving_engine import BaseModelPath, LoRAModulePath
 from utils import DummyRequest, JobInput, BatchSize, create_error_response
 from constants import DEFAULT_MAX_CONCURRENCY, DEFAULT_BATCH_SIZE, DEFAULT_BATCH_SIZE_GROWTH_FACTOR, DEFAULT_MIN_BATCH_SIZE
 from tokenizer import TokenizerWrapper
-from engine_args import get_engine_args
+from engine_args import get_engine_args, DEFAULT_ARGS
 
 class vLLMEngine:
     def __init__(self, engine = None):
@@ -146,6 +146,8 @@ class OpenAIvLLMEngine(vLLMEngine):
             base_model_paths=self.base_model_paths,
             response_role=self.response_role,
             chat_template=self.tokenizer.tokenizer.chat_template,
+            enable_auto_tools=DEFAULT_ARGS.enable_auto_tool_choice,
+            tool_parser=DEFAULT_ARGS.tool_call_parser,
             lora_modules=lora_modules,
             prompt_adapters=None,
             request_logger=None

--- a/src/engine.py
+++ b/src/engine.py
@@ -17,7 +17,7 @@ from vllm.entrypoints.openai.serving_engine import BaseModelPath, LoRAModulePath
 from utils import DummyRequest, JobInput, BatchSize, create_error_response
 from constants import DEFAULT_MAX_CONCURRENCY, DEFAULT_BATCH_SIZE, DEFAULT_BATCH_SIZE_GROWTH_FACTOR, DEFAULT_MIN_BATCH_SIZE
 from tokenizer import TokenizerWrapper
-from engine_args import get_engine_args, DEFAULT_ARGS
+from engine_args import get_engine_args
 
 class vLLMEngine:
     def __init__(self, engine = None):

--- a/src/engine_args.py
+++ b/src/engine_args.py
@@ -89,9 +89,7 @@ DEFAULT_ARGS = {
     "qlora_adapter_name_or_path": os.getenv('QLORA_ADAPTER_NAME_OR_PATH', None),
     "disable_logprobs_during_spec_decoding": os.getenv('DISABLE_LOGPROBS_DURING_SPEC_DECODING', None),
     "otlp_traces_endpoint": os.getenv('OTLP_TRACES_ENDPOINT', None),
-    "use_v2_block_manager": os.getenv('USE_V2_BLOCK_MANAGER', 'true'),
-    "enable_auto_tool_choice": os.getenv('ENABLE_AUTO_TOOL_CHOICE', 'false').lower() == 'true',
-    "tool_call_parser": os.getenv('TOOL_CALL_PARSER', "") or None
+    "use_v2_block_manager": os.getenv('USE_V2_BLOCK_MANAGER', 'true')
 }
 
 def match_vllm_args(args):


### PR DESCRIPTION
It looks like #133 isn't enough to actually enable tool calling, as these aren't engine args. They must instead be passed to `OpenAIServingChat` [like it's done here](https://github.com/vllm-project/vllm/blob/main/vllm/entrypoints/openai/api_server.py#L573-L574).

This change was tested using a forked worker image and is now working as intended.