### PR TITLE
completing the option for "bitsandbytes" based on  https://docs.vllm.ai/en/stable/quantization/bnb.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Below is a summary of the available RunPod Worker images, categorized by image s
 | `MAX_NUM_SEQS`                            | 256                   | `int`                                      | Maximum number of sequences per iteration. |
 | `MAX_LOGPROBS`                            | 20                    | `int`                                      | Max number of log probs to return when logprobs is specified in SamplingParams. |
 | `DISABLE_LOG_STATS`                       | False                 | `bool`                                     | Disable logging statistics. |
-| `QUANTIZATION`                            | None                  | ['awq', 'squeezellm', 'gptq']              | Method used to quantize the weights. |
+| `QUANTIZATION`                            | None                  | ['awq', 'squeezellm', 'gptq'. 'bitsandbytes']              | Method used to quantize the weights. |
 | `ROPE_SCALING`                            | None                  | `dict`                                     | RoPE scaling configuration in JSON format. |
 | `ROPE_THETA`                              | None                  | `float`                                    | RoPE theta. Use with rope_scaling. |
 | `TOKENIZER_POOL_SIZE`                     | 0                     | `int`                                      | Size of tokenizer pool to use for asynchronous tokenization. |

--- a/builder/requirements.txt
+++ b/builder/requirements.txt
@@ -9,3 +9,4 @@ pydantic
 pydantic-settings
 hf-transfer
 transformers
+bitsandbytes>=0.45.0

--- a/src/engine_args.py
+++ b/src/engine_args.py
@@ -147,8 +147,8 @@ def get_engine_args():
     # Rename and match to vllm args
     args = match_vllm_args(args)
 
-    if args.load_format=="bitsandbytes": 
-        args.quantization = args.load_format
+    if args.get("load_format") == "bitsandbytes":
+        args["quantization"] = args["load_format"]
     
     # Set tensor parallel size and max parallel loading workers if more than 1 GPU is available
     num_gpus = device_count()

--- a/src/engine_args.py
+++ b/src/engine_args.py
@@ -146,6 +146,9 @@ def get_engine_args():
     
     # Rename and match to vllm args
     args = match_vllm_args(args)
+
+    if args.load_format=="bitsandbytes": 
+        args.quantization = args.load_format
     
     # Set tensor parallel size and max parallel loading workers if more than 1 GPU is available
     num_gpus = device_count()

--- a/worker-config.json
+++ b/worker-config.json
@@ -558,14 +558,15 @@
     "env_var_name": "QUANTIZATION",
     "value": "",
     "title": "Quantization",
-    "description": "Method used to quantize the weights.",
+    "description": "Method used to quantize the weights.\nif the `Load Format` is 'bitsandbytes' then `Quantization` will be forced to 'bitsandbytes'",
     "required": false,
     "type": "select",
     "options": [
       { "value": "None", "label": "None" },
       { "value": "awq", "label": "AWQ" },
       { "value": "squeezellm", "label": "SqueezeLLM" },
-      { "value": "gptq", "label": "GPTQ" }
+      { "value": "gptq", "label": "GPTQ" },
+      { "value": "bitsandbytes", "label": "bitsandbytes" }
     ]
   },
   "ROPE_SCALING": {


### PR DESCRIPTION
in https://docs.vllm.ai/en/stable/quantization/bnb.html there are 3 things to do 

1. Installting `bitsandbytes>=0.45.0`
2.  `quantization="bitsandbytes"`
3.  `load_format="bitsandbytes"`

### Current state for `runpod-workers/worker-vllm:main` 
the `load_format="bitsandbytes"` is available 

### `mohamednaji7/worker-vllm:main` is ahead for 
1. added `bitsandbytes>=0.45.0` to the `requirements.txt`
2. [after checking `args.load_format`] forced `args.quantization`  since it is the only quantization for `load_format="bitsandbytes"`
3. updated the `QUANTIZATION` row in `RAEDME.md`
4. updated `QUANTIZATION` option in `worker-config.json`
