### PR TITLE
fix: added back limit_mm_per_prompt to engine args

### DIFF
--- a/src/engine_args.py
+++ b/src/engine_args.py
@@ -91,6 +91,7 @@ DEFAULT_ARGS = {
     "disable_logprobs_during_spec_decoding": os.getenv('DISABLE_LOGPROBS_DURING_SPEC_DECODING', None),
     "otlp_traces_endpoint": os.getenv('OTLP_TRACES_ENDPOINT', None),
     "use_v2_block_manager": os.getenv('USE_V2_BLOCK_MANAGER', 'true'),
+    "limit_mm_per_prompt": convert_limit_mm_per_prompt(os.getenv('LIMIT_MM_PER_PROMPT', "image=1"))
 }
 
 def match_vllm_args(args):

--- a/src/engine_args.py
+++ b/src/engine_args.py
@@ -91,7 +91,7 @@ DEFAULT_ARGS = {
     "disable_logprobs_during_spec_decoding": os.getenv('DISABLE_LOGPROBS_DURING_SPEC_DECODING', None),
     "otlp_traces_endpoint": os.getenv('OTLP_TRACES_ENDPOINT', None),
     "use_v2_block_manager": os.getenv('USE_V2_BLOCK_MANAGER', 'true'),
-    "limit_mm_per_prompt": convert_limit_mm_per_prompt(os.getenv('LIMIT_MM_PER_PROMPT', "image=1"))
+    "limit_mm_per_prompt": convert_limit_mm_per_prompt(os.getenv('LIMIT_MM_PER_PROMPT', "image=1")),
 }
 
 def match_vllm_args(args):

--- a/worker-config.json
+++ b/worker-config.json
@@ -25,7 +25,7 @@
             "TYPICAL_ACCEPTANCE_SAMPLER_POSTERIOR_THRESHOLD", "TYPICAL_ACCEPTANCE_SAMPLER_POSTERIOR_ALPHA",
             "MODEL_LOADER_EXTRA_CONFIG", "PREEMPTION_MODE", "PREEMPTION_CHECK_PERIOD",
             "PREEMPTION_CPU_CAPACITY", "MAX_LOG_LEN", "DISABLE_LOGGING_REQUEST",
-            "ENABLE_AUTO_TOOL_CHOICE", "TOOL_CALL_PARSER"
+            "ENABLE_AUTO_TOOL_CHOICE", "TOOL_CALL_PARSER", "LIMIT_MM_PER_PROMPT"
           ]
         },
         {
@@ -1262,6 +1262,14 @@
       { "value": "pythonic", "label": "Pythonic" },
       { "value": "internlm", "label": "InternLM" }
     ]
+  },
+  "LIMIT_MM_PER_PROMPT": {
+    "env_var_name": "LIMIT_MM_PER_PROMPT",
+    "value": "image=1",
+    "title": "Limit MM Per Prompt",
+    "description": "Limit MM per prompt",
+    "required": false,
+    "type": "text"
   }
 }
 }


### PR DESCRIPTION
Added back the engine argument `limit_mm_per_prompt` that was accidentally removed as per #155 