### PR TITLE
remove requirements for MODEL_NAME in local_model_args.json

### DIFF
--- a/src/engine_args.py
+++ b/src/engine_args.py
@@ -122,7 +122,7 @@ def get_local_args():
         local_args = json.load(f)
 
     if local_args.get("MODEL_NAME") is None:
-        raise ValueError("Model name not found in /local_model_args.json. There was a problem when baking the model in.")
+        logging.warning("Model name not found in /local_model_args.json. There maybe was a problem when baking the model in.")
 
     logging.info(f"Using baked in model with args: {local_args}")
     os.environ["TRANSFORMERS_OFFLINE"] = "1"


### PR DESCRIPTION
We want to use the same local_model_args.json for multiple models which have different names. It would be very convenient to only have a single local_args file and not have to create it every time

A warning should be enough for users