### PR TITLE
Add multimodal limit parameter support

### DIFF
--- a/src/engine_args.py
+++ b/src/engine_args.py
@@ -91,6 +91,7 @@ DEFAULT_ARGS = {
     "disable_logprobs_during_spec_decoding": os.getenv('DISABLE_LOGPROBS_DURING_SPEC_DECODING', None),
     "otlp_traces_endpoint": os.getenv('OTLP_TRACES_ENDPOINT', None),
     "use_v2_block_manager": os.getenv('USE_V2_BLOCK_MANAGER', 'true'),
+    "limit_mm_per_prompt": convert_limit_mm_per_prompt(os.getenv('LIMIT_MM_PER_PROMPT', 'image=1,video=0')),
 }
 
 def match_vllm_args(args):

--- a/src/utils.py
+++ b/src/utils.py
@@ -15,9 +15,14 @@ except ImportError:
 
 logging.basicConfig(level=logging.INFO)
 
+# Updated to parse multiple comma-separated multimodal limits (e.g., 'image=1,video=0')
 def convert_limit_mm_per_prompt(input_string: str):
-    key, value = input_string.split('=')
-    return {key: int(value)}
+    result = {}
+    pairs = input_string.split(',')
+    for pair in pairs:
+        key, value = pair.split('=')
+        result[key] = int(value)
+    return result
 
 def count_physical_cores():
     with open('/proc/cpuinfo') as f:


### PR DESCRIPTION
- Updated convert_limit_mm_per_prompt to handle multiple types
- Added limit_mm_per_prompt parameter for image and video limits

Note: Consider adjusting default values - perhaps image limit > 1 or video=1


Please add this - it's impossible to use OpenGVLab/InternVL3-14B without this change. Other multimodal models have the same problem probably. Thanks.