### PR TITLE
Fix rope_scaling dict parsing

### DIFF
--- a/src/engine_args.py
+++ b/src/engine_args.py
@@ -46,7 +46,7 @@ DEFAULT_ARGS = {
     "max_logprobs": int(os.getenv('MAX_LOGPROBS', 20)),  # Default value for OpenAI Chat Completions API
     "revision": os.getenv('REVISION', None),
     "code_revision": os.getenv('CODE_REVISION', None),
-    "rope_scaling": os.getenv('ROPE_SCALING', None),
+    "rope_scaling": json.loads(os.getenv("ROPE_SCALING", "null")),
     "rope_theta": float(os.getenv('ROPE_THETA', 0)) or None,
     "tokenizer_revision": os.getenv('TOKENIZER_REVISION', None),
     "quantization": os.getenv('QUANTIZATION', None),


### PR DESCRIPTION
Fixes https://github.com/runpod-workers/worker-vllm/issues/192 by correctly parsing the expected (https://github.com/vllm-project/vllm/blob/main/vllm/engine/arg_utils.py#L354C5-L354C17) json to a dict instead of just passing the string

Tested by deploying to Runpod with `Menlo/Jan-nano-128k` and `ROPE_SCALING={"rope_type":"yarn","factor":3.2,"original_max_position_embeddings":40960}`

Still waiting for the build to test if it works without specifying the env var