### PR TITLE
Update requirements and engine creation to support new 0.10.0 vLLM version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,11 +12,11 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     python3 -m pip install --upgrade -r /requirements.txt
 
 # Install vLLM (switching back to pip installs since issues that required building fork are fixed and space optimization is not as important since caching) and FlashInfer 
-RUN python3 -m pip install vllm==0.9.1 && \
+RUN python3 -m pip install vllm==0.10.0 && \
     python3 -m pip install flashinfer -i https://flashinfer.ai/whl/cu121/torch2.3
 
 # Setup for Option 2: Building the Image with the Model included
-ARG MODEL_NAME="openai/gpt-oss-120b"
+ARG MODEL_NAME=""
 ARG TOKENIZER_NAME=""
 ARG BASE_PATH="/runpod-volume"
 ARG QUANTIZATION=""

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN python3 -m pip install vllm==0.9.1 && \
     python3 -m pip install flashinfer -i https://flashinfer.ai/whl/cu121/torch2.3
 
 # Setup for Option 2: Building the Image with the Model included
-ARG MODEL_NAME=""
+ARG MODEL_NAME="openai/gpt-oss-120b"
 ARG TOKENIZER_NAME=""
 ARG BASE_PATH="/runpod-volume"
 ARG QUANTIZATION=""

--- a/builder/requirements.txt
+++ b/builder/requirements.txt
@@ -8,5 +8,7 @@ typing-extensions>=4.8.0
 pydantic
 pydantic-settings
 hf-transfer
-transformers
+transformers>=4.55.0
 bitsandbytes>=0.45.0
+kernels
+torch==2.6.0

--- a/src/engine.py
+++ b/src/engine.py
@@ -207,7 +207,6 @@ class OpenAIvLLMEngine(vLLMEngine):
             model_config=self.model_config,
             base_model_paths=self.base_model_paths,
             lora_modules=self.lora_adapters,
-            prompt_adapters=None,
         )
         await self.serving_models.init_static_loras()
         


### PR DESCRIPTION
With the update of GPT-OSS the version used of vLLM don't work because the Transformer library doesn't support the architecture type of GPT-OSS.