### PR TITLE
fix: allow "None" as value & parse the value of RAW_OPENAI_OUTPUT correctly

### DIFF
--- a/src/engine.py
+++ b/src/engine.py
@@ -178,7 +178,12 @@ class OpenAIvLLMEngine(vLLMEngine):
         self.response_role = os.getenv("OPENAI_RESPONSE_ROLE") or "assistant"
         self.lora_adapters = self._load_lora_adapters()
         asyncio.run(self._initialize_engines())
-        self.raw_openai_output = bool(int(os.getenv("RAW_OPENAI_OUTPUT", 1)))
+        # Handle both integer and boolean string values for RAW_OPENAI_OUTPUT
+        raw_output_env = os.getenv("RAW_OPENAI_OUTPUT", "1")
+        if raw_output_env.lower() in ('true', 'false'):
+            self.raw_openai_output = raw_output_env.lower() == 'true'
+        else:
+            self.raw_openai_output = bool(int(raw_output_env))
 
     def _load_lora_adapters(self):
         adapters = []

--- a/src/engine_args.py
+++ b/src/engine_args.py
@@ -111,7 +111,7 @@ def match_vllm_args(args):
     """
     renamed_args = {RENAME_ARGS_MAP.get(k, k): v for k, v in args.items()}
     matched_args = {k: v for k, v in renamed_args.items() if k in AsyncEngineArgs.__dataclass_fields__}
-    return {k: v for k, v in matched_args.items() if v not in [None, ""]}
+    return {k: v for k, v in matched_args.items() if v not in [None, "", "None"]}
 def get_local_args():
     """
     Retrieve local arguments from a JSON file.


### PR DESCRIPTION
## Motivation

while testing the worker in the hub, two problems came up that are solved with this pr:

* when a user is specifying `None` (as string) for example for `QUANTIZATION`, then vLLM will not start
* when a user is specifying `true` or `false` for `RAW_OPENAI_OUTPUT`, then vLLM will not start

both problems are solved with this pr. 