### PR TITLE
fix(config): update allowed cuda versions in hub and tests config

### DIFF
--- a/.runpod/hub.json
+++ b/.runpod/hub.json
@@ -9,17 +9,7 @@
     "containerDiskInGb": 150,
     "gpuIds": "ADA_80_PRO, AMPERE_80",
     "gpuCount": 1,
-    "allowedCudaVersions": [
-      "12.9",
-      "12.8",
-      "12.7",
-      "12.6",
-      "12.5",
-      "12.4",
-      "12.3",
-      "12.2",
-      "12.1"
-    ],
+    "allowedCudaVersions": ["12.9", "12.8", "12.7", "12.6", "12.5", "12.4"],
     "presets": [
       {
         "name": "deepseek-ai/deepseek-r1-distill-llama-8b",

--- a/.runpod/tests.json
+++ b/.runpod/tests.json
@@ -38,16 +38,6 @@
         "value": "HuggingFaceTB/SmolLM2-135M-Instruct"
       }
     ],
-    "allowedCudaVersions": [
-      "12.9",
-      "12.8",
-      "12.7",
-      "12.6",
-      "12.5",
-      "12.4",
-      "12.3",
-      "12.2",
-      "12.1"
-    ]
+    "allowedCudaVersions": ["12.9", "12.8", "12.7", "12.6", "12.5"]
   }
 }


### PR DESCRIPTION
remove unsupported cuda versions (12.1-12.3) from hub.json and tests.json to fix compatibility issues with worker deployment

- hub.json: remove 12.1, 12.2, 12.3 from allowedCudaVersions
- tests.json: remove 12.1, 12.2, 12.3, 12.4 from allowedCudaVersions

refs: AE-1452