### PR TITLE
Add structured outputs support to Runpod API

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ The vLLM Worker is fully compatible with OpenAI's API, and you can use it with a
 
 2. Change the `model` parameter to your deployed model's name whenever using Completions or Chat Completions.
    - Before:
+
    ```python
    response = client.chat.completions.create(
        model="gpt-3.5-turbo",
@@ -154,7 +155,9 @@ The vLLM Worker is fully compatible with OpenAI's API, and you can use it with a
        max_tokens=100,
    )
    ```
+
    - After:
+
    ```python
    response = client.chat.completions.create(
        model="<YOUR DEPLOYED MODEL REPO/NAME>",
@@ -168,6 +171,7 @@ The vLLM Worker is fully compatible with OpenAI's API, and you can use it with a
 
 1. Change the `Authorization` header to your RunPod API Key and the `url` to your RunPod Serverless Endpoint URL in the following format: `https://api.runpod.ai/v2/<YOUR ENDPOINT ID>/openai/v1`
    - Before:
+
    ```bash
    curl https://api.openai.com/v1/chat/completions \
    -H "Content-Type: application/json" \
@@ -184,7 +188,9 @@ The vLLM Worker is fully compatible with OpenAI's API, and you can use it with a
    "max_tokens": 100
    }'
    ```
+
    - After:
+
    ```bash
    curl https://api.runpod.ai/v2/<YOUR ENDPOINT ID>/openai/v1/chat/completions \
    -H "Content-Type: application/json" \
@@ -202,7 +208,7 @@ The vLLM Worker is fully compatible with OpenAI's API, and you can use it with a
    }'
    ```
 
-## OpenAI Request Input Parameters:
+## OpenAI Request Input Parameters
 
 When using the chat completion feature of the vLLM Serverless Endpoint Worker, you can customize your requests with the following parameters:
 
@@ -262,11 +268,12 @@ client = OpenAI(
 )
 ```
 
-### Chat Completions:
+### Chat Completions
 
 This is the format used for GPT-4 and focused on instruction-following and chat. Examples of Open Source chat/instruct models include `meta-llama/Llama-2-7b-chat-hf`, `mistralai/Mixtral-8x7B-Instruct-v0.1`, `openchat/openchat-3.5-0106`, `NousResearch/Nous-Hermes-2-Mistral-7B-DPO` and more. However, if your model is a completion-style model with no chat/instruct fine-tune and/or does not have a chat template, you can still use this if you provide a chat template with the environment variable `CUSTOM_CHAT_TEMPLATE`.
 
 - **Streaming**:
+
   ```python
   # Create a chat completion stream
   response_stream = client.chat.completions.create(
@@ -280,7 +287,9 @@ This is the format used for GPT-4 and focused on instruction-following and chat.
   for response in response_stream:
       print(chunk.choices[0].delta.content or "", end="", flush=True)
   ```
+
 - **Non-Streaming**:
+
   ```python
   # Create a chat completion
   response = client.chat.completions.create(
@@ -293,7 +302,7 @@ This is the format used for GPT-4 and focused on instruction-following and chat.
   print(response.choices[0].message.content)
   ```
 
-### Getting a list of names for available models:
+### Getting a list of names for available models
 
 In the case of baking the model into the image, sometimes the repo may not be accepted as the `model` in the request. In this case, you can list the available models as shown below and use that name.
 
@@ -309,8 +318,9 @@ print(list_of_models)
 
 <details>
   <summary>Click to expand table</summary>
-    
+
   You may either use a `prompt` or a list of `messages` as input. If you use `messages`, the model's chat template will be applied to the messages automatically, so the model must have one. If you use `prompt`, you may optionally apply the model's chat template to the prompt by setting `apply_chat_template` to `true`.
+
   | Argument              | Type                 | Default            | Description                                                                                            |
   |-----------------------|----------------------|--------------------|--------------------------------------------------------------------------------------------------------|
   | `prompt`              | str                  |                    | Prompt string to generate text based on.                                                               |
@@ -321,6 +331,7 @@ print(list_of_models)
   | `max_batch_size`          | int                  | env var `DEFAULT_BATCH_SIZE` | The maximum number of tokens to stream every HTTP POST call.                                                   |
   | `min_batch_size`          | int                  | env var `DEFAULT_MIN_BATCH_SIZE` | The minimum number of tokens to stream every HTTP POST call.                                           |
   | `batch_size_growth_factor` | int                  | env var `DEFAULT_BATCH_SIZE_GROWTH_FACTOR` | The growth factor by which `min_batch_size` will be multiplied for each call until `max_batch_size` is reached.           |
+
 </details>
 
 ### Sampling Parameters
@@ -355,7 +366,7 @@ Below are all available sampling parameters that you can specify in the `samplin
 
 You may either use a `prompt` or a list of `messages` as input.
 
-1.  `prompt`
+1. `prompt`
     The prompt string can be any string, and the model's chat template will not be applied to it unless `apply_chat_template` is set to `true`, in which case it will be treated as a user message.
 
         Example:
@@ -371,7 +382,7 @@ You may either use a `prompt` or a list of `messages` as input.
         }
         ```
 
-2.  `messages`
+2. `messages`
     Your list can contain any number of messages, and each message usually can have any role from the following list: - `user` - `assistant` - `system`
 
     However, some models may have different roles, so you should check the model's chat template to see which roles are required.

--- a/README.md
+++ b/README.md
@@ -228,6 +228,9 @@ When using the chat completion feature of the vLLM Serverless Endpoint Worker, y
 | `user`              | Optional[str]                    | None          | Unsupported by vLLM                                                                                                                                                                                                                                          |
 
 Additional parameters supported by vLLM:
+
+| Parameter           | Type                             | Default Value | Description                                                                                                                                                                                                                                                  |
+| ------------------- | -------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `best_of` | Optional[int] | None | Number of output sequences that are generated from the prompt. From these `best_of` sequences, the top `n` sequences are returned. `best_of` must be greater than or equal to `n`. This is treated as the beam width when `use_beam_search` is True. By default, `best_of` is set to `n`. |
 | `top_k` | Optional[int] | -1 | Integer that controls the number of top tokens to consider. Set to -1 to consider all tokens. |
 | `ignore_eos` | Optional[bool] | False | Whether to ignore the EOS token and continue generating tokens after the EOS token is generated. |

--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ Additional parameters supported by vLLM:
 | `stop_token_ids` | Optional[List[int]] | list | List of tokens that stop the generation when they are generated. The returned output will contain the stop tokens unless the stop tokens are special tokens. |
 | `skip_special_tokens` | Optional[bool] | True | Whether to skip special tokens in the output. |
 | `spaces_between_special_tokens`| Optional[bool] | True | Whether to add spaces between special tokens in the output. Defaults to True. |
+| `structured_outputs` | Optional[dict] | None | Constrains generations to JSON schemas, regexes, grammar, etc. See [Structured Outputs](https://docs.vllm.ai/en/latest/features/structured_outputs/). |
 | `add_generation_prompt` | Optional[bool] | True | Read more [here](https://huggingface.co/docs/transformers/main/en/chat_templating#what-are-generation-prompts) |
 | `echo` | Optional[bool] | False | Echo back the prompt in addition to the completion |
 | `repetition_penalty` | Optional[float] | 1.0 | Float that penalizes new tokens based on whether they appear in the prompt and the generated text so far. Values > 1 encourage the model to use new tokens, while values < 1 encourage the model to repeat tokens. |
@@ -415,5 +416,34 @@ You may either use a `prompt` or a list of `messages` as input.
       }
     }
     ```
+
+#### Structured Outputs
+
+The RunPod API mirrors vLLM's offline inference API directly. To enforce JSON schemas, regexes, grammar rules, or structural tags, provide a `structured_outputs` object directly inside `sampling_params`. The structure matches the `SamplingParams(structured_outputs=StructuredOutputsParams(...))` API from vLLM (`json`, `regex`, `choice`, `grammar`, `structural_tag`, etc.). Example enforcing a JSON schema:
+
+```json
+{
+  "input": {
+    "messages": [
+      {"role": "user", "content": "Return a JSON document with name and age"}
+    ],
+    "sampling_params": {
+      "max_tokens": 128,
+      "structured_outputs": {
+        "json": {
+          "type": "object",
+          "properties": {
+            "name": {"type": "string"},
+            "age": {"type": "integer"}
+          },
+          "required": ["name", "age"]
+        }
+      }
+    }
+  }
+}
+```
+
+For all supported structured output types and usage patterns, refer to the vLLM [Structured Outputs guide](https://docs.vllm.ai/en/v0.11.1.1/features/structured_outputs/).
 
 </details>

--- a/src/utils.py
+++ b/src/utils.py
@@ -56,15 +56,15 @@ class JobInput:
         # self.sampling_params = SamplingParams(max_tokens=100, **job.get("sampling_params", {}))
         self.request_id = random_uuid()
         batch_size_growth_factor = job.get("batch_size_growth_factor")
-        self.batch_size_growth_factor = float(batch_size_growth_factor) if batch_size_growth_factor else None 
+        self.batch_size_growth_factor = float(batch_size_growth_factor) if batch_size_growth_factor else None
         min_batch_size = job.get("min_batch_size")
-        self.min_batch_size = int(min_batch_size) if min_batch_size else None 
+        self.min_batch_size = int(min_batch_size) if min_batch_size else None
         self.openai_route = job.get("openai_route")
         self.openai_input = job.get("openai_input")
 class DummyState:
     def __init__(self):
         self.request_metadata = None
-        
+
 class DummyRequest:
     def __init__(self):
         self.headers = {}
@@ -82,16 +82,16 @@ class BatchSize:
             self.current_batch_size = min_batch_size
         else:
             self.current_batch_size = max_batch_size
-        
+
     def update(self):
         if self.is_dynamic:
             self.current_batch_size = min(self.current_batch_size*self.batch_size_growth_factor, self.max_batch_size)
-        
+
 def create_error_response(message: str, err_type: str = "BadRequestError", status_code: HTTPStatus = HTTPStatus.BAD_REQUEST) -> ErrorResponse:
     return ErrorResponse(message=message,
                             type=err_type,
                             code=status_code.value)
-    
+
 def get_int_bool_env(env_var: str, default: bool) -> bool:
     return int(os.getenv(env_var, int(default))) == 1
 


### PR DESCRIPTION
Add support for structured outputs (JSON schema, regex, choice, grammar,
and structural_tag constraints) using vLLM 0.11.0+'s
StructuredOutputsParams API.

Changes:
- Import StructuredOutputsParams from vllm.sampling_params
- Extract structured_outputs from extra_body in sampling_params
- Create StructuredOutputsParams instances for json, regex, choice,
  grammar, and structural_tag constraint types
- Reject deprecated guided_json parameter (from vLLM <0.11.0) with
  clear error message pointing to migration guide

This enables users to enforce JSON schemas and other structured output
formats on model responses, as documented in vLLM 0.11.0.

https://docs.vllm.ai/en/v0.11.0/features/structured_outputs.html

Fixes #235
