### PR TITLE
refactor: Update CI workflow to support runpod>= versioning

### DIFF
--- a/.github/workflows/CI-runpod_dep.yml
+++ b/.github/workflows/CI-runpod_dep.yml
@@ -21,8 +21,8 @@ jobs:
         run: |
           echo "Fetching the current runpod version from requirements.txt..."
           
-          # Get current version, allowing both == and ~= in the search pattern
-          current_version=$(grep -oP 'runpod[~=]{1,2}\K[^"]+' ./builder/requirements.txt)
+          # Get current version, supporting ==, ~=, and >= operators
+          current_version=$(grep -oP 'runpod[>~=]+\K[^"]+' ./builder/requirements.txt)
           echo "Current version: $current_version"
 
           if [ -z "$current_version" ]; then
@@ -30,17 +30,41 @@ jobs:
               exit 1
           fi
 
-          # Compare versions using sort -V (version sort)
+          echo "Fetching the latest runpod version from PyPI..."
+          new_version=$(curl -s https://pypi.org/pypi/runpod/json | jq -r .info.version)
+          echo "NEW_VERSION=$new_version" >> $GITHUB_ENV
+          echo "New version from PyPI: $new_version"
+
+          if [ -z "$new_version" ]; then
+              echo "ERROR: Failed to fetch the new version from PyPI."
+              exit 1
+          fi
+
+          # Check for exact version match
           if [ "$current_version" = "$new_version" ]; then
               echo "No update needed. Already at version $new_version."
               exit 0
           fi
 
-          # Check if new version is actually newer
+          # Check if new version is actually newer using semantic version comparison
           newer_version=$(printf "%s\n%s" "$current_version" "$new_version" | sort -V | tail -n1)
           if [ "$newer_version" = "$current_version" ]; then
               echo "No update needed. Current version ($current_version) is already >= new version ($new_version)."
               exit 0
           fi
 
-          echo "New version detected ($new_version > $current_version). Updating runpod version..."
+          echo "New version detected ($new_version > $current_version). Updating requirements.txt..."
+          sed -i "s/runpod[>~=]*[0-9.]*/runpod>=$new_version/" ./builder/requirements.txt
+          echo "requirements.txt has been updated to runpod>=$new_version"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: Update runpod to ${{ env.NEW_VERSION }}"
+          title: "chore: Update runpod to latest version"
+          body: |
+            Automated update of runpod package version.
+
+            New version: ${{ env.NEW_VERSION }}
+          branch: runpod-package-update

--- a/.github/workflows/CI-runpod_dep.yml
+++ b/.github/workflows/CI-runpod_dep.yml
@@ -25,43 +25,22 @@ jobs:
           current_version=$(grep -oP 'runpod[~=]{1,2}\K[^"]+' ./builder/requirements.txt)
           echo "Current version: $current_version"
 
-          # Extract major and minor from current version
-          current_major_minor=$(echo $current_version | cut -d. -f1,2)
-          echo "Current major.minor: $current_major_minor"
-
-          echo "Fetching the latest runpod version from PyPI..."
-          
-          # Get new version from PyPI
-          new_version=$(curl -s https://pypi.org/pypi/runpod/json | jq -r .info.version)
-          echo "NEW_VERSION_ENV=$new_version" >> $GITHUB_ENV
-          echo "New version: $new_version"
-
-          # Extract major and minor from new version
-          new_major_minor=$(echo $new_version | cut -d. -f1,2)
-          echo "New major.minor: $new_major_minor"
-
-          if [ -z "$new_version" ]; then
-              echo "ERROR: Failed to fetch the new version from PyPI."
+          if [ -z "$current_version" ]; then
+              echo "ERROR: Failed to extract current version from requirements.txt."
               exit 1
           fi
 
-          # Check if the major or minor version is different
-          if [ "$current_major_minor" = "$new_major_minor" ]; then
-              echo "No update needed. The new version ($new_major_minor) is within the allowed range (~= $current_major_minor)."
+          # Compare versions using sort -V (version sort)
+          if [ "$current_version" = "$new_version" ]; then
+              echo "No update needed. Already at version $new_version."
               exit 0
           fi
 
-          echo "New major/minor detected ($new_major_minor). Updating requirements.txt..."
+          # Check if new version is actually newer
+          newer_version=$(printf "%s\n%s" "$current_version" "$new_version" | sort -V | tail -n1)
+          if [ "$newer_version" = "$current_version" ]; then
+              echo "No update needed. Current version ($current_version) is already >= new version ($new_version)."
+              exit 0
+          fi
 
-          # Update requirements.txt, preserving the existing constraint type (~= or ==)
-          sed -i "s/runpod[~=][^ ]*/runpod~=$new_version/" ./builder/requirements.txt
-          echo "requirements.txt has been updated."
-
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: Update runpod package version
-          title: Update runpod package version
-          body: The package version has been updated to ${{ env.NEW_VERSION_ENV }}
-          branch: runpod-package-update
+          echo "New version detected ($new_version > $current_version). Updating runpod version..."

--- a/builder/requirements.txt
+++ b/builder/requirements.txt
@@ -1,7 +1,7 @@
 ray
 pandas
 pyarrow
-runpod~=1.7.7
+runpod>=1.8.0
 huggingface-hub
 packaging
 typing-extensions>=4.8.0


### PR DESCRIPTION
Changes:
- Update grep pattern from runpod~= to runpod>=
- Replace major.minor range logic with semantic version comparison
- Add validation for current_version extraction
- Update sed replacement to maintain >= operator
- Workflow now triggers on any version increase (patch, minor, major)

Previously, the workflow only updated for major.minor changes due to ~= (compatible release) constraint. Now with >=, all new releases are honored.