### PR TITLE
fix: remove FlashInfer due to version mismatch with vLLM 0.11.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,10 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     python3 -m pip install --upgrade pip && \
     python3 -m pip install --upgrade -r /requirements.txt
 
-# Install vLLM (switching back to pip installs since issues that required building fork are fixed and space optimization is not as important since caching) and FlashInfer 
-RUN python3 -m pip install vllm==0.11.0 && \
-    python3 -m pip install flashinfer -i https://flashinfer.ai/whl/cu121/torch2.3
+# Install vLLM (switching back to pip installs since issues that required building fork are fixed and space optimization is not as important since caching)
+# Note: FlashInfer removed due to version mismatch with vLLM 0.11.0's torch/CUDA versions
+# vLLM will use FlashAttention or other backends automatically
+RUN python3 -m pip install vllm==0.11.0
 
 # Setup for Option 2: Building the Image with the Model included
 ARG MODEL_NAME=""


### PR DESCRIPTION
FlashInfer was installed for cu121/torch2.3 but vLLM 0.11.0 brings torch 2.8.0, causing binary incompatibility and import errors.

vLLM will automatically use FlashAttention or other backends.

Fixes unhealthy workers caused by FlashInfer import errors.