### PR TITLE
Upgrade vLLM to 0.12.0 and remove FlashInfer from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     python3 -m pip install --upgrade -r /requirements.txt
 
 # Install vLLM (switching back to pip installs since issues that required building fork are fixed and space optimization is not as important since caching) and FlashInfer 
-RUN python3 -m pip install vllm==0.11.0 && \
-    python3 -m pip install flashinfer -i https://flashinfer.ai/whl/cu121/torch2.3
+RUN python3 -m pip install vllm==0.12.0 
 
 # Setup for Option 2: Building the Image with the Model included
 ARG MODEL_NAME=""

--- a/src/engine.py
+++ b/src/engine.py
@@ -202,14 +202,12 @@ class OpenAIvLLMEngine(vLLMEngine):
         return adapters
 
     async def _initialize_engines(self):
-        self.model_config = await self.llm.get_model_config()
         self.base_model_paths = [
             BaseModelPath(name=self.engine_args.model, model_path=self.engine_args.model)
         ]
 
         self.serving_models = OpenAIServingModels(
             engine_client=self.llm,
-            model_config=self.model_config,
             base_model_paths=self.base_model_paths,
             lora_modules=self.lora_adapters,
         )
@@ -222,7 +220,6 @@ class OpenAIvLLMEngine(vLLMEngine):
         
         self.chat_engine = OpenAIServingChat(
             engine_client=self.llm, 
-            model_config=self.model_config,
             models=self.serving_models,
             response_role=self.response_role,
             request_logger=None,
@@ -237,7 +234,6 @@ class OpenAIvLLMEngine(vLLMEngine):
         )
         self.completion_engine = OpenAIServingCompletion(
             engine_client=self.llm, 
-            model_config=self.model_config,
             models=self.serving_models,
             request_logger=None,
             # return_token_as_token_ids=False,


### PR DESCRIPTION

This PR upgrades vLLM to version 0.12.0 and removes FlashInfer from the Dockerfile.

As part of the update, I removed all uses of get_model_config() from OpenAIServingModels, OpenAIServingChat, and OpenAIServingCompletion.
In vLLM 0.12.0, this method has been moved internally and replaced by the model_config attribute, so calling it manually causes issues with the newer version.

The updated Dockerfile has been fully rebuilt and deployed, and the DeepSeek OCR functionality is working correctly after these changes.

This PR also addresses the issues discussed in:
#247 
#245 

@TimPietruskyRunPod 

and thanks for the serverless platform 

<img width="1486" height="715" alt="image" src="https://github.com/user-attachments/assets/f13e80b1-1a2c-476f-a626-b13f8e9b9238" />
