### PR TITLE
fix: update CUDA to 12.4.1 for Blackwell GPU support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,8 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     python3 -m pip install --upgrade pip && \
     python3 -m pip install --upgrade -r /requirements.txt
 
-# Install vLLM and FlashInfer
-RUN python3 -m pip install vllm==0.11.0 && \
-    python3 -m pip install flashinfer-python
+# Install vLLM
+RUN python3 -m pip install vllm==0.11.0
 
 # Setup for Option 2: Building the Image with the Model included
 ARG MODEL_NAME=""


### PR DESCRIPTION
## Summary
- Updates Dockerfile base image from CUDA 12.1.0 to 12.4.1
- Updates ldconfig path to cuda-12.4  
- removes flashinfer
- Adds `NVIDIA B200` (Blackwell) to supported gpuIds in hub.json

## Problem
vLLM workers fail on Blackwell GPUs (RTX PRO 6000, B200) with:
```
imagePullAsync: failed to get self-hosted image registry auth
```

This was caused by a CUDA version mismatch:
- Dockerfile used CUDA 12.1.0
- `hub.json` `allowedCudaVersions` only allows 12.4-12.9 (12.1 was removed in commit f8bf824)

## Test plan
- [x] Wait for CI to build the dev image
- [x] Create a test endpoint on RunPod with a Blackwell GPU (B200)
- [x] Verify worker starts successfully without the `imagePullAsync` error
- [x] Run a simple inference test

Fixes: DR-1118