### PR TITLE
feat: add TASK environment variable for embedding models

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ To build an image with the model baked in, you must specify the following docker
   - `MODEL_NAME`
 - **Optional**
   - `MODEL_REVISION`: Model revision to load (default: `main`).
+  - `TASK`: The task to use for the model, e.g. `embed` for embedding models (default: `auto`).
   - `BASE_PATH`: Storage directory where huggingface cache and model will be located. (default: `/runpod-volume`, which will utilize network storage if you attach it or create a local directory within the image if you don't. If your intention is to bake the model into the image, you should set this to something like `/models` to make sure there are no issues if you were to accidentally attach network storage.)
   - `QUANTIZATION`
   - `WORKER_CUDA_VERSION`: `12.1.0` (`12.1.0` is recommended for optimal performance).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,6 +8,7 @@ Complete guide to all environment variables and configuration options for worker
 | ------------------------------ | ------------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------- |
 | `MODEL_NAME`                   | 'facebook/opt-125m' | `str`                                                       | Name or path of the Hugging Face model to use.                                  |
 | `MODEL_REVISION`               | 'main'              | `str`                                                       | Model revision to load (default: main).                                         |
+| `TASK`                         | 'auto'              | `str`                                                       | The task to use for the model (e.g., `embed` for embedding models).             |
 | `TOKENIZER`                    | None                | `str`                                                       | Name or path of the Hugging Face tokenizer to use.                              |
 | `SKIP_TOKENIZER_INIT`          | False               | `bool`                                                      | Skip initialization of tokenizer and detokenizer.                               |
 | `TOKENIZER_MODE`               | 'auto'              | ['auto', 'slow']                                            | The tokenizer mode.                                                             |

--- a/src/engine_args.py
+++ b/src/engine_args.py
@@ -68,6 +68,7 @@ DEFAULT_ARGS = {
     "long_lora_scaling_factors": tuple(map(float, os.getenv('LONG_LORA_SCALING_FACTORS', '').split(','))) if os.getenv('LONG_LORA_SCALING_FACTORS') else None,
     "lora_dtype": os.getenv('LORA_DTYPE', 'auto'),
     "max_cpu_loras": int(os.getenv('MAX_CPU_LORAS', 0)) or None,
+    "task": os.getenv('TASK', 'auto'),
     "device": os.getenv('DEVICE', 'auto'),
     "ray_workers_use_nsight": os.getenv('RAY_WORKERS_USE_NSIGHT', 'False').lower() == 'true',
     "num_gpu_blocks_override": int(os.getenv('NUM_GPU_BLOCKS_OVERRIDE', 0)) or None,


### PR DESCRIPTION
## Summary

- Adds a `TASK` environment variable (default: `auto`) that exposes vllm's `--task` CLI argument
- Enables running embedding models (e.g. `BAAI/bge-multilingual-gemma2`, Qwen3-VL) that require `--task embed`
- Documents the new variable in `docs/configuration.md`

Closes #170

## Test plan

- [ ] Set `TASK=embed` and verify an embedding model loads correctly with `--task embed`
- [ ] Verify default (`auto`) behavior is unchanged for generation models