### PR TITLE
fix: restrict transformers version to be less than 4.57.7

### DIFF
--- a/builder/requirements.txt
+++ b/builder/requirements.txt
@@ -8,7 +8,7 @@ typing-extensions>=4.8.0
 pydantic
 pydantic-settings
 hf-transfer
-transformers>=4.57.0
+transformers>=4.57.0,<4.57.7
 bitsandbytes>=0.45.0
 kernels
 torch==2.6.0


### PR DESCRIPTION
When building/running this worker, `transformers` is currently not constrained (or effectively `>=4.57.0` without an upper bound), so pip may install `transformers` 5.x. The image pins vLLM to an older version (e.g. `vllm==0.11.0` on `main`), and the combination is incompatible.

At runtime, vLLM fails during tokenizer initialization with:
`AttributeError: TokenizersBackend has no attribute all_special_tokens_extended`

This prevents the worker from starting at all.