### PR TITLE
docs: clarify RunPod env mapping for Qwen deployment

### DIFF
--- a/.runpod/hub.json
+++ b/.runpod/hub.json
@@ -186,7 +186,7 @@
         "input": {
           "name": "Max Model Length",
           "type": "number",
-          "description": "Model context length.",
+          "description": "Model context length (maps to vLLM --max-model-len).",
           "default": null,
           "advanced": true
         }
@@ -517,7 +517,7 @@
         "input": {
           "name": "Speculative Model",
           "type": "string",
-          "description": "The name of the draft model to be used in speculative decoding.",
+          "description": "Draft model for speculative decoding (equivalent to vLLM speculative draft model).",
           "advanced": true
         }
       },
@@ -590,7 +590,7 @@
         "input": {
           "name": "GPU Memory Utilization",
           "type": "number",
-          "description": "Sets GPU VRAM utilization",
+          "description": "Sets GPU VRAM utilization (maps to vLLM --gpu-memory-utilization).",
           "default": 0.95,
           "advanced": true
         }
@@ -748,33 +748,7 @@
         "input": {
           "name": "Tool Call Parser",
           "type": "string",
-          "description": "Tool call parser",
-          "options": [
-            {
-              "label": "None",
-              "value": ""
-            },
-            {
-              "label": "Hermes",
-              "value": "hermes"
-            },
-            {
-              "label": "Mistral",
-              "value": "mistral"
-            },
-            {
-              "label": "Llama3 JSON",
-              "value": "llama3_json"
-            },
-            {
-              "label": "Pythonic",
-              "value": "pythonic"
-            },
-            {
-              "label": "InternLM",
-              "value": "internlm"
-            }
-          ],
+          "description": "Tool call parser name passed directly to vLLM OpenAI serving (for example: mistral, hermes, llama3_json, qwen3_xml when supported by your vLLM version). Leave empty to disable.",
           "default": "",
           "advanced": true
         }

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Configure worker-vllm using environment variables:
 | `MAX_NUM_SEQS`                      | Maximum number of sequences per iteration         | 256                 | Integer                                                            |
 | `CUSTOM_CHAT_TEMPLATE`              | Custom chat template override                     |                     | Jinja2 template string                                             |
 | `ENABLE_AUTO_TOOL_CHOICE`           | Enable automatic tool selection                   | false               | boolean (true or false)                                            |
-| `TOOL_CALL_PARSER`                  | Parser for tool calls                             |                     | "mistral", "hermes", "llama3_json", "granite", "deepseek_v3", etc. |
+| `TOOL_CALL_PARSER`                  | Parser for tool calls                             |                     | Free-form parser string (for example "mistral", "hermes", "llama3_json", "qwen3_xml" if supported by your vLLM build) |
 | `OPENAI_SERVED_MODEL_NAME_OVERRIDE` | Override served model name in API                 |                     | String                                                             |
 | `MAX_CONCURRENCY`                   | Maximum concurrent requests                       | 30                  | Integer                                                            |
 
@@ -70,6 +70,50 @@ Configure worker-vllm using environment variables:
 Any env var whose name matches a valid `AsyncEngineArgs` field (uppercased) is applied automatically. Backward-compat aliases: `MODEL_NAME`, `TOKENIZER_NAME`, `MAX_CONTEXT_LEN_TO_CAPTURE`. This lets you configure any vLLM option without waiting for explicit worker support.
 
 For the complete list of all available environment variables, examples, and detailed descriptions: **[Configuration](docs/configuration.md)**
+
+RunPod template UI fields are convenience inputs. If a specific parser or advanced argument is not listed in a dropdown, you can still set the matching environment variable directly and the worker will pass it through.
+
+#### CLI to Env Mapping (Serverless)
+
+| vLLM CLI flag | Env var in this worker |
+| --- | --- |
+| `--max-model-len` | `MAX_MODEL_LEN` |
+| `--gpu-memory-utilization` | `GPU_MEMORY_UTILIZATION` |
+| `--tensor-parallel-size` | `TENSOR_PARALLEL_SIZE` |
+| `--enforce-eager` | `ENFORCE_EAGER` |
+| `--enable-prefix-caching` | `ENABLE_PREFIX_CACHING` |
+| `--enable-auto-tool-choice` | `ENABLE_AUTO_TOOL_CHOICE` |
+| `--tool-call-parser` | `TOOL_CALL_PARSER` |
+| `--enable-prompt-tokens-details` | `ENABLE_PROMPT_TOKENS_DETAILS` |
+| `--speculative_draft_model` | `SPECULATIVE_MODEL` |
+
+`--host` and `--port` are not used here because RunPod serverless manages ingress.
+
+#### Qwen Example (RunPod Endpoint Env Vars)
+
+```bash
+MODEL_NAME=RedHatAI/Qwen3-Coder-Next-NVFP4
+TENSOR_PARALLEL_SIZE=1
+GPU_MEMORY_UTILIZATION=0.70
+MAX_MODEL_LEN=262144
+ENFORCE_EAGER=true
+ENABLE_AUTO_TOOL_CHOICE=true
+TOOL_CALL_PARSER=qwen3_xml
+ENABLE_PROMPT_TOKENS_DETAILS=true
+ENABLE_PREFIX_CACHING=true
+SPECULATIVE_METHOD=draft_model
+SPECULATIVE_MODEL=Qwen/qwen2.5-coder-1.5b
+```
+
+#### GPU Memory Utilization Guidance (Serverless)
+
+Start `GPU_MEMORY_UTILIZATION` conservatively and increase only after validating real prompts:
+
+- `0.70` to `0.80`: long context, prefix caching, or speculative decoding
+- `0.80` to `0.90`: typical chat/instruct workloads
+- `0.90` to `0.95`: highest throughput after stability validation
+
+For this Qwen setup (`MAX_MODEL_LEN=262144` with prefix caching/speculative decoding), keep `0.70` as the default starting point.
 
 ## Option 2: Build Docker Image with Model Inside
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -127,7 +127,7 @@ The way this works is that the first request will have a batch size of `DEFAULT_
 | `OPENAI_SERVED_MODEL_NAME_OVERRIDE` | `None`      | `str`            | Overrides the name of the served model from model repo/path to specified name, which you will then be able to use the value for the `model` parameter when making OpenAI requests                                 |
 | `OPENAI_RESPONSE_ROLE`              | `assistant` | `str`            | Role of the LLM's Response in OpenAI Chat Completions.                                                                                                                                                            |
 | `ENABLE_AUTO_TOOL_CHOICE`           | `false`     | `bool`           | Enables automatic tool selection for supported models. Set to `true` to activate.                                                                                                                                 |
-| `TOOL_CALL_PARSER`                  | `None`      | `str`            | Specifies the parser for tool calls. Options: `mistral`, `hermes`, `llama3_json`, `llama4_json`, `llama4_pythonic`, `granite`, `granite-20b-fc`, `deepseek_v3`, `internlm`, `jamba`, `phi4_mini_json`, `pythonic` |
+| `TOOL_CALL_PARSER`                  | `None`      | `str`            | Specifies the parser for tool calls. Examples: `mistral`, `hermes`, `llama3_json`, `llama4_json`, `llama4_pythonic`, `granite`, `granite-20b-fc`, `deepseek_v3`, `internlm`, `jamba`, `phi4_mini_json`, `pythonic`, `qwen3_xml` (if supported by your vLLM build). |
 | `REASONING_PARSER`                  | `None`      | `str`            | Parser for reasoning-capable models (enables reasoning mode). Examples: `deepseek_r1`, `qwen3`, `granite`, `hunyuan_a13b`. Leave unset to disable.                                                                |
 | `TRUST_REQUEST_CHAT_TEMPLATE`       | `false`     | `bool`           | Allow clients to send custom chat templates in API requests. **Security consideration:** Only enable if you trust your API clients.                                                                               |
 | `RETURN_TOKENS_AS_TOKEN_IDS`        | `false`     | `bool`           | Return token IDs instead of decoded text strings in responses.                                                                                                                                                     |
@@ -178,6 +178,61 @@ Any vLLM `AsyncEngineArgs` field can be set via an environment variable using th
 - Only valid `AsyncEngineArgs` fields are applied. Unknown keys are silently ignored.
 - Values are automatically cast to the correct type (`int`, `float`, `bool`, `str`, or JSON for `dict`/`list`/`tuple`).
 - For a full list of available engine args, see the [vLLM AsyncEngineArgs documentation](https://docs.vllm.ai/en/latest/configuration/engine_args/).
+
+## CLI Flag to Env Var Mapping (RunPod Serverless)
+
+If you are coming from `vllm serve ...` flags, use these env vars in RunPod endpoint configuration:
+
+| vLLM CLI flag | Worker env var | Notes |
+| --- | --- | --- |
+| `--max-model-len` | `MAX_MODEL_LEN` | Same numeric value. |
+| `--gpu-memory-utilization` | `GPU_MEMORY_UTILIZATION` | Float between `0.0` and `1.0`. |
+| `--tensor-parallel-size` | `TENSOR_PARALLEL_SIZE` | On multi-GPU workers this repo may auto-set tensor parallel to GPU count. |
+| `--enforce-eager` | `ENFORCE_EAGER` | Set to `true` or `false`. |
+| `--enable-prefix-caching` | `ENABLE_PREFIX_CACHING` | Enables vLLM prefix caching. |
+| `--enable-auto-tool-choice` | `ENABLE_AUTO_TOOL_CHOICE` | OpenAI-compatible tool auto-selection. |
+| `--tool-call-parser` | `TOOL_CALL_PARSER` | Free-form parser name, e.g. `qwen3_xml` when supported. |
+| `--enable-prompt-tokens-details` | `ENABLE_PROMPT_TOKENS_DETAILS` | Adds prompt token details in OpenAI responses. |
+| `--speculative_draft_model` | `SPECULATIVE_MODEL` | Uses speculative decoding draft model wiring in this worker. |
+
+`--host` and `--port` do not apply to this serverless worker. RunPod manages ingress; configure the endpoint via env vars.
+
+## Qwen Serverless Example
+
+Example endpoint env configuration equivalent to your requested setup:
+
+```bash
+MODEL_NAME=RedHatAI/Qwen3-Coder-Next-NVFP4
+TENSOR_PARALLEL_SIZE=1
+GPU_MEMORY_UTILIZATION=0.70
+MAX_MODEL_LEN=262144
+ENFORCE_EAGER=true
+ENABLE_AUTO_TOOL_CHOICE=true
+TOOL_CALL_PARSER=qwen3_xml
+ENABLE_PROMPT_TOKENS_DETAILS=true
+ENABLE_PREFIX_CACHING=true
+SPECULATIVE_METHOD=draft_model
+SPECULATIVE_MODEL=Qwen/qwen2.5-coder-1.5b
+```
+
+## Recommended GPU Memory Utilization (Serverless)
+
+`GPU_MEMORY_UTILIZATION` controls how much VRAM vLLM reserves for weights, activations, and KV cache. On serverless, leaving some headroom usually improves startup and runtime stability.
+
+Suggested starting points:
+
+| Workload profile | Recommended start |
+| --- | --- |
+| Long context or speculative decoding enabled | `0.70` to `0.80` |
+| General chat/instruct workloads | `0.80` to `0.90` |
+| Maximum throughput after stability is confirmed | `0.90` to `0.95` |
+
+Tuning guidance:
+
+- If you see OOMs during warmup or first large prompts, lower by `0.05`.
+- If stable under production prompt lengths, increase gradually by `0.02` to `0.03`.
+- Prefix caching and long contexts increase KV cache pressure; keep extra headroom for those workloads.
+- For your Qwen config (`MAX_MODEL_LEN=262144`, prefix caching, speculative decoding), `0.70` is a good conservative default.
 
 ## Docker Build Arguments
 


### PR DESCRIPTION
Document CLI-to-env mappings, add Qwen serverless examples, and make tool parser configuration less restrictive in the RunPod template.