### PR TITLE
fix: make .runpod/tests.json hub tests pass on CUDA 13.0

### DIFF
--- a/.runpod/tests.json
+++ b/.runpod/tests.json
@@ -5,7 +5,7 @@
       "input": {
         "prompt": "Write a short poem about artificial intelligence."
       },
-      "timeout": 30000
+      "timeout": 300000
     },
     {
       "name": "openai_messages_test",
@@ -26,7 +26,7 @@
           "temperature": 0.1
         }
       },
-      "timeout": 30000
+      "timeout": 300000
     }
   ],
   "config": {
@@ -38,6 +38,6 @@
         "value": "HuggingFaceTB/SmolLM2-135M-Instruct"
       }
     ],
-    "allowedCudaVersions": ["12.9", "12.8", "12.7", "12.6", "12.5"]
+    "allowedCudaVersions": ["13.0"]
   }
 }

--- a/builder/requirements.txt
+++ b/builder/requirements.txt
@@ -11,5 +11,5 @@ pydantic-settings
 hf-transfer
 transformers>=5
 bitsandbytes>=0.45.0
-kernels
+kernels<0.15
 torch-c-dlpack-ext


### PR DESCRIPTION
## Summary

Three coupled fixes so the re-enabled hub tests from #295 actually pass. Verified end-to-end on a private fork — both `basic_inference_test` and `openai_messages_test` green on v0.1.3.

### What was broken

After v2.20.0 (#288) bumped the base image to CUDA 13.0, the hub-test flow had three independent failures stacked on top of each other. Each one masked the next:

1. **CUDA version mismatch in `tests.json`** — `allowedCudaVersions` was still `["12.9", "12.8", "12.7", "12.6", "12.5"]` so the test pod was scheduled on a driver < 13.0 and container init aborted at the `nvidia-container-cli` hook with `unsatisfied condition: cuda>=13.0`.

2. **`kernels` 0.15.1 breaking `transformers`** — [`kernels` v0.15.0 (#544)](https://github.com/huggingface/kernels/pull/544) tightened `LayerRepository` to require `revision=` or `version=`. `transformers>=5` still constructs `LayerRepository(repo_id=..., layer_name=...)` without either ([`hub_kernels.py:89`](https://github.com/huggingface/transformers/blob/main/src/transformers/integrations/hub_kernels.py#L89)), so worker import raises `ValueError` at module-load time. Pinning `kernels<0.15` keeps us on 0.14.1 which doesn't have the strict check.

3. **Test timeout too tight for vLLM cold start** — vLLM 0.20.2 `torch.compile` + FlashInfer warmup on RTX 4090 takes ~60–70s before the first inference is served (observed: `torch.compile took 19.34 s` + warmup + model load). The 30s per-test timeout fired before the worker came up, producing `context cancelled or timed out: context deadline exceeded` for every test even when the worker was healthy. Bumping to 300s.

### Changes

- `.runpod/tests.json`: `allowedCudaVersions` → `["13.0"]`; both test `timeout` → `300000`
- `builder/requirements.txt`: `kernels` → `kernels<0.15`

### Validation

Private fork `TimPietruskyRunPod/worker-vllm`, identical code path, four iterations to isolate each bug:

| Tag | Change | Result |
|---|---|---|
| v0.1.0 | upstream mirror | Container init fail — `cuda>=13.0` |
| v0.1.1 | + CUDA 13.0 | Worker boot fail — `kernels.LayerRepository` ValueError |
| v0.1.2 | + `kernels<0.15` | vLLM up (`torch.compile 19.34s`), tests timeout @ 30s |
| **v0.1.3** | + 300s timeout | **2/2 tests passing** |

Refs: [DR-1161](https://linear.app/runpod/issue/DR-1161/re-enable-vllm-worker-runpodtestsjson-hub-tests)

## Test plan

- [ ] PR build kicks off (`dev-refs-pull-<N>-merge`)
- [ ] Hub tests pass on this PR's image: `basic_inference_test` ✓ and `openai_messages_test` ✓
- [ ] After merge + version bump release, the same tests pass on `runpod/worker-v1-vllm:vX.Y.Z`