### PR TITLE
Bump vLLM to v0.27.1

### DIFF
--- a/.cache/vllm_serve_flags.json
+++ b/.cache/vllm_serve_flags.json
@@ -287,5 +287,5 @@
     "--worker-cls",
     "--worker-extension-cls"
   ],
-  "vllm_version": "0.27.0"
+  "vllm_version": "0.27.1"
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Worker image = official vLLM OpenAI server image + RunPod serverless wrapper.
 # vLLM upgrades are now a single build ARG:
 #   docker buildx build --build-arg VLLM_VERSION=v0.23.0 ...
-ARG VLLM_VERSION=v0.27.0
+ARG VLLM_VERSION=v0.27.1
 FROM vllm/vllm-openai:${VLLM_VERSION}
 
 # RunPod serverless SDK + HTTP proxy deps (vLLM itself comes from the base image).


### PR DESCRIPTION
Bumps the vLLM base image (`ARG VLLM_VERSION` in Dockerfile) from v0.27.0 to v0.27.1.
Release notes: https://github.com/vllm-project/vllm/releases/tag/v0.27.1

## Serve-flag drift check (vllm 0.27.1)

✅ **0 drift errors, no flag changes.** Local dump of the real `vllm serve` parser inside `vllm/vllm-openai:v0.27.1` (76 bool-pair / 5 store-true / 201 value flags) is identical to 0.27.0 — the refreshed snapshot in `.cache/vllm_serve_flags.json` differs only in version string. 121 upstream flags remain unmapped (informational, unchanged from v0.27.0).

No `src/args_builder.py` changes needed.

_Generated by the daily scheduled release check; drift check run locally via `scripts/check_vllm_flags.py` against the published base image._
