### PR TITLE
fix: Update tests and hub listing

### DIFF
--- a/.runpod/hub.json
+++ b/.runpod/hub.json
@@ -185,9 +185,9 @@
         "key": "MAX_MODEL_LEN",
         "input": {
           "name": "Max Model Length",
-          "type": "number",
+          "type": "string",
           "description": "Model context length.",
-          "default": -1,
+          "default": "auto",
           "advanced": true
         }
       },

--- a/.runpod/hub.json
+++ b/.runpod/hub.json
@@ -187,7 +187,7 @@
           "name": "Max Model Length",
           "type": "number",
           "description": "Model context length.",
-          "default": null,
+          "default": -1,
           "advanced": true
         }
       },

--- a/.runpod/tests.json
+++ b/.runpod/tests.json
@@ -30,7 +30,7 @@
     }
   ],
   "config": {
-    "gpuTypeId": "NVIDIA L40",
+    "gpuTypeId": "NVIDIA A40",
     "gpuCount": 1,
     "env": [
       {


### PR DESCRIPTION
This PR updates tests.json to use a GPU that's more readily available in all environments, it also updates the hub listing to set MAX_MODEL_LEN to a string and be set to "auto" by default. 