### PR TITLE
Bump vLLM to v0.28.0

### DIFF
--- a/.cache/vllm_serve_flags.json
+++ b/.cache/vllm_serve_flags.json
@@ -3,7 +3,6 @@
     "--allow-credentials",
     "--allow-deprecated-quantization",
     "--async-scheduling",
-    "--calculate-kv-scales",
     "--cohere-is-reasoning-model",
     "--cudagraph-metrics",
     "--data-parallel-external-lb",
@@ -62,9 +61,11 @@
     "--kv-sharing-fast-prefill",
     "--language-model-only",
     "--log-error-stack",
+    "--mm-device-do-normalize",
     "--mm-encoder-only",
     "--numa-bind",
     "--ray-workers-use-nsight",
+    "--return-sampling-mask",
     "--return-tokens-as-token-ids",
     "--scheduler-reserve-full-isl",
     "--skip-mm-profiling",
@@ -136,6 +137,7 @@
     "--dp-supervisor-probe-interval-s",
     "--dp-supervisor-probe-timeout-s",
     "--dtype",
+    "--ec-manager-config",
     "--ec-transfer-config",
     "--eplb-config",
     "--expert-placement-strategy",
@@ -207,6 +209,7 @@
     "--mm-ipc-gpu-memory-gb",
     "--mm-processor-cache-gb",
     "--mm-processor-cache-type",
+    "--mm-processor-device",
     "--mm-processor-kwargs",
     "--mm-shm-cache-max-object-size-mb",
     "--mm-tensor-ipc",
@@ -227,7 +230,6 @@
     "--offload-prefetch-step",
     "--optimization-level",
     "--otlp-traces-endpoint",
-    "--override-attention-dtype",
     "--override-generation-config",
     "--performance-mode",
     "--pipeline-parallel-size",
@@ -287,5 +289,5 @@
     "--worker-cls",
     "--worker-extension-cls"
   ],
-  "vllm_version": "0.27.1"
+  "vllm_version": "0.28.0"
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Worker image = official vLLM OpenAI server image + RunPod serverless wrapper.
 # vLLM upgrades are now a single build ARG:
 #   docker buildx build --build-arg VLLM_VERSION=v0.23.0 ...
-ARG VLLM_VERSION=v0.27.1
+ARG VLLM_VERSION=v0.28.0
 FROM vllm/vllm-openai:${VLLM_VERSION}
 
 # RunPod serverless SDK + HTTP proxy deps (vLLM itself comes from the base image).

--- a/builder/requirements.txt
+++ b/builder/requirements.txt
@@ -3,3 +3,7 @@
 runpod~=1.12.0
 aiohttp>=3.9
 huggingface-hub>=0.24
+# bitsandbytes moved out of vLLM core into an out-of-tree plugin in v0.28.0
+# (vllm-project/vllm#43529); without it LOAD_FORMAT/QUANTIZATION=bitsandbytes
+# configs die at model load. vLLM auto-loads it via entry points on startup.
+vllm-bnb-plugin>=0.0.3

--- a/src/args_builder.py
+++ b/src/args_builder.py
@@ -139,7 +139,6 @@ VALUE_FLAGS = frozenset({
     "--model-loader-extra-config",
     "--num-gpu-blocks-override",
     "--otlp-traces-endpoint",
-    "--override-attention-dtype",
     "--override-generation-config",
     "--pipeline-parallel-size",
     "--pooler-config",
@@ -182,7 +181,6 @@ VALUE_FLAGS = frozenset({
 PAIRED_BOOL_FLAGS = frozenset({
     "--allow-credentials",
     "--async-scheduling",
-    "--calculate-kv-scales",
     "--data-parallel-hybrid-lb",
     "--disable-cascade-attn",
     "--disable-chunked-mm-input",
@@ -241,6 +239,7 @@ ZERO_MEANS_UNSET = frozenset({
 # nothing instead of dying with `unrecognized arguments` at container start.
 # The note names the replacement (if any) and appears in the warning.
 REMOVED_FLAGS = {
+    "--calculate-kv-scales": "removed in v0.28.0 (#49389); no replacement",
     "--cuda-graph-sizes": "moved into COMPILATION_CONFIG as cudagraph_capture_sizes",
     "--disable-frontend-multiprocessing": "no replacement",
     "--disable-log-requests": "inverted upstream; use ENABLE_LOG_REQUESTS=false",
@@ -260,6 +259,7 @@ REMOVED_FLAGS = {
     "--max-num-partial-prefills": "removed in v0.27.0; no replacement",
     "--num-lookahead-slots": "speculative decoding is configured via SPECULATIVE_CONFIG",
     "--num-redundant-experts": "now a field of EPLB_CONFIG (--eplb-config)",
+    "--override-attention-dtype": "removed in v0.28.0 (#48684); no replacement",
     "--override-pooler-config": "use POOLER_CONFIG (--pooler-config)",
     "--rope-scaling": "pass rope_scaling via HF_OVERRIDES (--hf-overrides)",
     "--rope-theta": "pass rope_theta via HF_OVERRIDES (--hf-overrides)",


### PR DESCRIPTION
Bumps the vLLM base image (`ARG VLLM_VERSION` in Dockerfile) from v0.27.1 to v0.28.0.
Release notes: https://github.com/vllm-project/vllm/releases/tag/v0.28.0

## Serve-flag drift check (vllm 0.28.0)

✅ **0 drift errors after fix.** Local dump of the real `vllm serve` parser inside `vllm/vllm-openai:v0.28.0` (77 bool-pair / 5 store-true / 202 value) initially flagged 2 flags removed upstream — handled in `src/args_builder.py` (commit 8953d82):

- `--override-attention-dtype` — removed upstream in v0.28.0 ([vllm-project/vllm#48684](https://github.com/vllm-project/vllm/pull/48684)); moved from `VALUE_FLAGS` to `REMOVED_FLAGS` (env var now warns and is ignored)
- `--calculate-kv-scales` — removed upstream in v0.28.0 ([vllm-project/vllm#49389](https://github.com/vllm-project/vllm/pull/49389)); moved from `PAIRED_BOOL_FLAGS` to `REMOVED_FLAGS` (same)

125 upstream flags remain unmapped (informational only). The refreshed snapshot (77/5/202) is committed in `.cache/vllm_serve_flags.json`.

## bitsandbytes (breaking change in v0.28.0)

vLLM v0.28.0 moved bitsandbytes out of core into the out-of-tree `vllm-bnb-plugin` ([vllm-project/vllm#43529](https://github.com/vllm-project/vllm/pull/43529)). Without it, the advertised `LOAD_FORMAT`/`QUANTIZATION=bitsandbytes` options (.runpod/hub.json, README) would fail at model load. Commit d849c71 adds `vllm-bnb-plugin>=0.0.3` to `builder/requirements.txt` — verified in the v0.28.0 base image: installs cleanly, registers the `bitsandbytes` `vllm.general_plugins` entry point, auto-loaded by vLLM at startup.

_Generated by the daily scheduled release check; drift check run locally via `scripts/check_vllm_flags.py` against the published base image._
