### PR TITLE
Add step to GPU_MEMORY_UTILIZATION hub input

### DIFF
--- a/.runpod/hub.json
+++ b/.runpod/hub.json
@@ -583,6 +583,7 @@
           "type": "number",
           "description": "Sets GPU VRAM utilization",
           "default": 0.95,
+          "step": 0.01,
           "advanced": true
         }
       },


### PR DESCRIPTION
## Description

Fixes in the console "Deploy vLLM" form, typing a float into **GPU Memory Utilization** (e.g. `0.92`) snapped to `1` on blur, and was deployed as `1`.

Root cause is on the listing side, p the console Hub deploy form already forwards each env input's `step` to the design-system `Input`, which quantizes typed values to the nearest step on blur. This input declared no `step`, so the console fell back to an implicit step of `1`.

This PR declares `"step": 0.01` for `GPU_MEMORY_UTILIZATION` — a float between 0 and 1 (default `0.95`). No console changes needed.

It is the only float-valued number input in this listing worth a step:

- `SCHEDULER_DELAY_FACTOR` and `DEFAULT_BATCH_SIZE*` entries are no longer wired to anything (`--scheduler-delay-factor` is not in the current allowlist in `src/args_builder.py`; the `DEFAULT_BATCH_SIZE*` vars are leftovers from the old v1 engine)
- everything else (`TENSOR_PARALLEL_SIZE`, `MAX_NUM_SEQS`, `BLOCK_SIZE`, …) is integer-valued and correctly snaps to whole numbers

## Release note

The Hub indexes releases, so this takes effect in the console deploy form with the next tagged worker-vllm release (the release workflow builds it from the tag).

- [x] `hub.json` still parses (`python -m json.tool`)
- [ ] Console deploy form keeps a typed `0.92` on blur — verifiable on the next release
