### PR TITLE
Hotfix: stop bnb plugin install from silently downgrading vLLM to 0.19.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,26 @@
 #   docker buildx build --build-arg VLLM_VERSION=v0.23.0 ...
 ARG VLLM_VERSION=v0.28.0
 FROM vllm/vllm-openai:${VLLM_VERSION}
+# Re-declare so the stage can reference it in RUN steps below.
+ARG VLLM_VERSION
 
 # RunPod serverless SDK + HTTP proxy deps (vLLM itself comes from the base image).
 COPY builder/requirements.txt /requirements.txt
 RUN python3 -m ensurepip --upgrade 2>/dev/null || true \
     && python3 -m pip install --no-cache-dir -r /requirements.txt
+
+# bitsandbytes moved out of vLLM core into the out-of-tree vllm-bnb-plugin in
+# v0.28.0 (vllm-project/vllm#43529). The --no-deps is load-bearing: the plugin
+# declares an UNPINNED `vllm` dependency, and letting pip resolve it replaces
+# the base image's vLLM — it once backtracked to vllm 0.19.1, producing an
+# image tagged v0.28.0 that actually contained 0.19.1 (broken deep_ep/NCCL
+# mix). Its only real runtime need is the `bitsandbytes` package, pinned in
+# builder/requirements.txt.
+RUN python3 -m pip install --no-cache-dir --no-deps "vllm-bnb-plugin>=0.0.3"
+
+# Guard rail: the base image's vLLM must survive our pip installs — fail the
+# build loudly if the installed version no longer matches the requested tag.
+RUN test "$(python3 -c 'import vllm; print(vllm.__version__)')" = "${VLLM_VERSION#v}"
 
 # Setup for Option 2: building the image with the model baked in.
 ARG MODEL_NAME=""

--- a/builder/requirements.txt
+++ b/builder/requirements.txt
@@ -5,5 +5,6 @@ aiohttp>=3.9
 huggingface-hub>=0.24
 # bitsandbytes moved out of vLLM core into an out-of-tree plugin in v0.28.0
 # (vllm-project/vllm#43529); without it LOAD_FORMAT/QUANTIZATION=bitsandbytes
-# configs die at model load. vLLM auto-loads it via entry points on startup.
-vllm-bnb-plugin>=0.0.3
+# configs die at model load. This is its runtime library — the plugin itself
+# is installed in the Dockerfile with --no-deps (see the comment there).
+bitsandbytes>=0.50.2


### PR DESCRIPTION
## What happened

The `vllm-bnb-plugin>=0.0.3` line added in #332 (commit `d849c71`) declares an unpinned `vllm` dependency. During image builds, `pip install -r builder/requirements.txt` re-resolved `vllm` and backtracked all the way to **vllm 0.19.1**, replacing the base image's 0.28.0 stack (torch 2.10.0, nvidia-nccl-cu12 2.27.5, triton 3.6.0, …) while the base's `deep_ep` (built against NCCL 2.30) survived. The result: the `dev-refs-pull-332-merge` image reports **vllm 0.19.1** despite the Dockerfile pinning v0.28.0, and MoE/engine-core startup dies with:

```
ImportError: deep_ep/_C...so: undefined symbol: ncclTeamWorld
```

(base's deep_ep needs `ncclTeamWorld`, only present in NCCL ≥2.26-era; the downgraded nccl-cu12 2.27.5 doesn't export it).

## Fix (`affa7c4`)

- `builder/requirements.txt` now carries only `bitsandbytes>=0.50.2` (the plugin's sole real runtime need)
- Dockerfile installs the plugin itself with `--no-deps` — pip can never re-resolve `vllm` from it again
- New build-time guard: the build **fails loudly** if the installed `vllm.__version__` doesn't match `ARG VLLM_VERSION`, so no silent downgrade of this class can ship again

## Verification

- Reproduced the user's runtime failure on a Runpod pod with the published dev image (engine core crashed with the exact `ncclTeamWorld` ImportError)
- Confirmed locally: base pull of `vllm/vllm-openai:v0.28.0` (digest `61fc8a89`) contains vllm 0.28.0; the fixed install sequence keeps it at 0.28.0, `bitsandbytes` imports, and the plugin registers its `vllm.general_plugins` entry point
- Guard line tested under `/bin/sh`

## Notes

- Public release images are unaffected (latest release `v2.25.2` predates #332); only the dev tag is poisoned, and BR builds built directly from current `main` would be too
- The `test-pr` e2e failure and the post-merge Serverless Model Tests failure on main are consistent with this bug
- Merging fixes `main`; anyone who deployed `dev-refs-pull-332-merge` should redeploy after rebuild
