### PR TITLE
e2e: set RUNPOD_INIT_TIMEOUT=1600 on test templates

### DIFF
--- a/scripts/serverless_e2e_test.py
+++ b/scripts/serverless_e2e_test.py
@@ -277,7 +277,7 @@ def main() -> int:
 
     hub_defaults = load_hub_defaults(args.hub_json)
     model_env = load_model_env(args.config)
-    env = {**hub_defaults["env"], **model_env}
+    env = {**hub_defaults["env"], **model_env, "RUNPOD_INIT_TIMEOUT": "1600"}
     hf_token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGINGFACE_ACCESS_TOKEN")
     if hf_token:
         env["HF_TOKEN"] = hf_token


### PR DESCRIPTION
Sets `RUNPOD_INIT_TIMEOUT=1600` in the env passed to the test template created by `scripts/serverless_e2e_test.py`, merged after the hub.json defaults and model config env so neither can override it.